### PR TITLE
feat: Add instructions to check if enable-shared build option used

### DIFF
--- a/v6.22.02/README.md
+++ b/v6.22.02/README.md
@@ -36,11 +36,13 @@ PYTHON_CONFIGURE_OPTS="--with-ensurepip --enable-optimizations --with-lto --enab
     pyenv install 3.8.7
 ```
 
-The easiest way to check that a Python runtime has been built with the `--enable-shared` option is to check the value of `Py_ENABLE_SHARED` in `sysconfig`
+The easiest way to check that a Python runtime has been built with the `--enable-shared` option is to check the value of `Py_ENABLE_SHARED` in the [`sysconfig`](https://docs.python.org/3/library/sysconfig.html) module
 
 ```shell
 python -c "import sysconfig; assert sysconfig.get_config_var('Py_ENABLE_SHARED') == 1"
 ```
+
+If this command runs without an `AssertionError` then `--enable-shared` was used during its build.
 
 ## ROOT build
 

--- a/v6.22.02/README.md
+++ b/v6.22.02/README.md
@@ -36,6 +36,12 @@ PYTHON_CONFIGURE_OPTS="--with-ensurepip --enable-optimizations --with-lto --enab
     pyenv install 3.8.7
 ```
 
+The easiest way to check that a Python runtime has been built with the `--enable-shared` option is to check the value of `Py_ENABLE_SHARED` in `sysconfig`
+
+```shell
+python -c "import sysconfig; assert sysconfig.get_config_var('Py_ENABLE_SHARED') == 1"
+```
+
 ## ROOT build
 
 Create a Python virtual environment for the build and install NumPy for ROOT to use


### PR DESCRIPTION
```
* Add instruction on using sysconfig to check if the enable-shared option was passed at CPython build time
   - If Py_ENABLE_SHARED is set to 1 then --enable-shared was used
   - c.f. https://docs.python.org/3/library/sysconfig.html
```