### PR TITLE
feat: Use faster install command

### DIFF
--- a/v6.22.02/build_ROOT.sh
+++ b/v6.22.02/build_ROOT.sh
@@ -41,6 +41,6 @@ cmake \
 cmake "root_build_${ROOT_VERSION}" -L
 cmake --build "root_build_${ROOT_VERSION}" -- -j$(($(nproc) - 1))
 
-# cmake --build "root_build_${ROOT_VERSION}" --target install
+# cmake --install "root_build_${ROOT_VERSION}"
 
 unset ROOT_VERSION

--- a/v6.30.02/README.md
+++ b/v6.30.02/README.md
@@ -2,9 +2,7 @@
 
 ## pyenv build configuration
 
-To get ROOT to build nicely and not get through the full build and then error at the end with something like
-
-[CPython will need to be built with the `--enable-shared` flag](https://github.com/pyenv/pyenv/wiki#how-to-build-cpython-with---enable-shared).
+To get ROOT to build nicely and not get through the full build and then error at the end, [CPython will need to be built with the `--enable-shared` flag](https://github.com/pyenv/pyenv/wiki#how-to-build-cpython-with---enable-shared).
 This can be done with pyenv by using the `PYTHON_CONFIGURE_OPTS` environmental variable
 
 ```shell

--- a/v6.30.02/build_ROOT.sh
+++ b/v6.30.02/build_ROOT.sh
@@ -47,6 +47,6 @@ cmake \
 if [ -d "${INSTALL_PREFIX}" ]; then
     rm -rf "${INSTALL_PREFIX}"
 fi
-cmake --build "root_build_${ROOT_VERSION}" --target install
+cmake --install "root_build_${ROOT_VERSION}"
 
 unset ROOT_VERSION


### PR DESCRIPTION
```
* Using `cmake --install` is faster as it doesn't trigger the
  build engine, but just directly does the copy and install step.
* Fix typo.

Co-authored-by: Henry Schreiner <henry.fredrick.schreiner@cern.ch>
```